### PR TITLE
Potential fix for code scanning alert no. 10: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/backend/internal/security/password.go
+++ b/backend/internal/security/password.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -141,39 +140,6 @@ func verifyLegacySaltHash(password, stored string) bool {
 		if subtle.ConstantTimeCompare(derived, expected) == 1 {
 			return true
 		}
-	}
-
-	// 2) Common legacy one-shot variants.
-	sha512SaltPwd := sha512.Sum512(append(append([]byte{}, salt...), []byte(password)...))
-	if subtle.ConstantTimeCompare(sha512SaltPwd[:], expected) == 1 {
-		return true
-	}
-
-	sha512PwdSalt := sha512.Sum512(append(append([]byte{}, []byte(password)...), salt...))
-	if subtle.ConstantTimeCompare(sha512PwdSalt[:], expected) == 1 {
-		return true
-	}
-
-	sha256SaltPwd := sha256.Sum256(append(append([]byte{}, salt...), []byte(password)...))
-	if subtle.ConstantTimeCompare(sha256SaltPwd[:], expected) == 1 {
-		return true
-	}
-
-	sha256PwdSalt := sha256.Sum256(append(append([]byte{}, []byte(password)...), salt...))
-	if subtle.ConstantTimeCompare(sha256PwdSalt[:], expected) == 1 {
-		return true
-	}
-
-	hmac512 := hmac.New(sha512.New, salt)
-	_, _ = hmac512.Write([]byte(password))
-	if subtle.ConstantTimeCompare(hmac512.Sum(nil), expected) == 1 {
-		return true
-	}
-
-	hmac256 := hmac.New(sha256.New, salt)
-	_, _ = hmac256.Write([]byte(password))
-	if subtle.ConstantTimeCompare(hmac256.Sum(nil), expected) == 1 {
-		return true
 	}
 
 	return false


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Sizzler/exodus/security/code-scanning/10](https://github.com/Adam-Sizzler/exodus/security/code-scanning/10)

General fix: stop accepting one-shot SHA-256/SHA-512 and HMAC-* password hash variants for login verification, and only allow computationally expensive password KDFs (bcrypt / PBKDF2). This removes weak password-hash handling while preserving supported secure formats.

Best single fix here (minimal, no functional expansion): in `backend/internal/security/password.go`, edit `verifyLegacySaltHash` to keep only the legacy PBKDF2 candidate checks and remove the “common legacy one-shot variants” section (SHA512/SHA256 sum and HMAC comparisons). That directly resolves the CodeQL sink at line 162 and related variants at same location, with no changes needed in handlers/utils.

Needed changes:
- No new imports or dependencies.
- Remove unused `crypto/hmac` import after deleting HMAC verification block.
- Replace the tail of `verifyLegacySaltHash` so it returns `false` after PBKDF2 checks fail.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
