### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/backend/internal/notifications/notifier.go
+++ b/backend/internal/notifications/notifier.go
@@ -763,9 +763,41 @@ func stringValue(data map[string]any, key string) string {
 }
 
 func intValue(data map[string]any, key string) int {
-	value := int64Value(data, key)
-	if value < int64(math.MinInt) || value > int64(math.MaxInt) {
+	if data == nil {
 		return 0
+	}
+
+	switch value := data[key].(type) {
+	case int:
+		return value
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, strconv.IntSize)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	case *string:
+		if value == nil {
+			return 0
+		}
+		parsed, err := strconv.ParseInt(strings.TrimSpace(*value), 10, strconv.IntSize)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	case json.Number:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value.String()), 10, strconv.IntSize)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	}
+
+	value := int64Value(data, key)
+	if strconv.IntSize == 32 {
+		if value < math.MinInt32 || value > math.MaxInt32 {
+			return 0
+		}
 	}
 	return int(value)
 }

--- a/backend/internal/notifications/notifier.go
+++ b/backend/internal/notifications/notifier.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -762,7 +763,11 @@ func stringValue(data map[string]any, key string) string {
 }
 
 func intValue(data map[string]any, key string) int {
-	return int(int64Value(data, key))
+	value := int64Value(data, key)
+	if value < int64(math.MinInt) || value > int64(math.MaxInt) {
+		return 0
+	}
+	return int(value)
 }
 
 func int64Value(data map[string]any, key string) int64 {


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Sizzler/exodus/security/code-scanning/6](https://github.com/Adam-Sizzler/exodus/security/code-scanning/6)

To fix this safely without changing intended behavior, add explicit bounds checks when converting `int64` to `int` in `backend/internal/notifications/notifier.go`:

- Keep `int64Value` as-is.
- Update `intValue` to:
  - read the `int64` once,
  - compare against `math.MinInt` / `math.MaxInt`,
  - return `0` (existing default-style fallback) when out of range,
  - otherwise convert to `int`.

This is the best minimal fix because:
- it directly addresses the vulnerable sink (`int(int64Value(...))`),
- it resolves all variants at that location,
- it preserves current semantics for normal in-range values,
- it avoids broad schema/type changes across other files.

Required changes:
- File: `backend/internal/notifications/notifier.go`
- Add import: `math`
- Replace `intValue` implementation with range-checked conversion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
