### PR TITLE
Potential fix for code scanning alert no. 4: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/backend/internal/httpapi/passkeys/handlers.go
+++ b/backend/internal/httpapi/passkeys/handlers.go
@@ -394,7 +394,6 @@ func VerifyAuthenticationHandler(manager *dbmanager.DatabaseManager, cfg *config
 			return
 		}
 
-		secureCookie := middleware.IsSecureRequest(r, cfg)
 		http.SetCookie(w, &http.Cookie{
 			Name:     passkeySessionCookieName,
 			Value:    sessionToken,
@@ -402,7 +401,7 @@ func VerifyAuthenticationHandler(manager *dbmanager.DatabaseManager, cfg *config
 			Expires:  time.Unix(expiresAt, 0).UTC(),
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
-			Secure:   secureCookie,
+			Secure:   true,
 		})
 
 		shared.WriteJSON(w, http.StatusOK, map[string]any{


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Sizzler/exodus/security/code-scanning/4](https://github.com/Adam-Sizzler/exodus/security/code-scanning/4)

To fix this, set the session cookie’s `Secure` attribute to `true` unconditionally when calling `http.SetCookie`.

Best minimal change without altering core behavior:
- In `backend/internal/httpapi/passkeys/handlers.go`, inside `VerifyAuthenticationHandler`, remove the conditional `secureCookie := middleware.IsSecureRequest(r, cfg)` usage for this cookie and set:
  - `Secure: true`
- No new imports, methods, or dependencies are needed.

This ensures the authentication cookie is never sent over HTTP, satisfying CodeQL and security best practice for session tokens.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
